### PR TITLE
Build/CI cleanup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,13 +11,19 @@ pylint_task:
     - pylint --version
     - pylint test
 
+clang_lint_task:
+  container:
+    image: debian:10-slim
+  install_script:
+    - "apt-get update && apt-get install -y clang clang-tools make bear"
+  script:
+    - make lint
+
 test_task:
   container:
     image: python:3.7-slim
   install_script:
-    - "apt-get update && apt-get install -y clang clang-tools make bear"
+    - "apt-get update && apt-get install -y clang make"
     - pip install pytest
-  lint_script:
-    - make lint
   script:
     - make test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC := clang
 CLANG_CHECK := clang-check
 
 CFLAGS := -std=c11 -pedantic-errors -fdiagnostics-show-option \
-			-Werror -Weverything -Wno-missing-noreturn -Wno-missing-braces \
+			-Werror -Weverything -Wno-missing-noreturn \
 			-D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE
 
 SRCFILES := $(wildcard src/*.c)

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,7 @@
+status = [
+    "pylint",
+    "clang lint",
+    "test",
+]
+
+delete_merged_branches = true

--- a/src/ish.c
+++ b/src/ish.c
@@ -174,7 +174,7 @@ static size_t shellsplit(Pipeline *pipeline, char input[CHARS_PER_LINE]) {
 }
 // Helper function: convert argc+argv to a Pipeline, then execute it.
 static int execute_a(size_t argc, char **argv) {
-    Pipeline pipeline = {0};
+    Pipeline pipeline = {{{{0}, 0}}};
     for (size_t i = 0; i < argc; i++) {
         pipeline.commands[0].tokens[i] = argv[i];
     }
@@ -370,7 +370,7 @@ static void handle(char buf[CHARS_PER_LINE]) { // Handle a line of input.
     if (strlen(buf) == 0) { // If it was _only_ a newline, bail.
         return;
     }
-    Pipeline pipeline = {0};
+    Pipeline pipeline = {{{{0}, 0}}};
     shellsplit(&pipeline, buf); // tokenize the line.
     int status = execute(&pipeline);
     setenv("?", int_to_str(intbuf, status), 1); 


### PR DESCRIPTION
1. ish having a weird `Pipeline` struct is the only reason for `-Wno-missing-braces`, so fix that instead of disabling that error.
2. Split out clang lint task.
3. Enable bors.