### PR TITLE
Make tests pass on macOS.

### DIFF
--- a/test/test_ish.py
+++ b/test/test_ish.py
@@ -135,7 +135,7 @@ def test_pipes():
     assert ish("echo hello, world '|' | sed 's/|/!/' | sed 's/ !/!/' | tr l w\n")['stdout'] == "hewwo, worwd!\n"
 
     command = "setenv X /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin\n" +\
-              "echo ${X} | sed 's/:/\\n/g' | awk '{print length, $0}' | sort -n | cut -f2- -d' '\n"
+              "echo ${X} | tr ':' '\\n' | awk '{print length, $0}' | sort -n | cut -f2- -d' '\n"
     assert ish(command)['stdout'] == "/usr/bin\n/root/bin\n/usr/sbin\n/usr/local/bin\n/usr/local/sbin\n"
 
 


### PR DESCRIPTION
This consisted of:

1. replacing a `sed` call with `tr` to avoid platform-specific behavior.
2. explicitly handling the situation where `rm -r file...` is given a file (not a directory), since `nftw()` apparently sometimes can't handle that.